### PR TITLE
Fix for case when not using div class control-group

### DIFF
--- a/src/bootstrap-filestyle.js
+++ b/src/bootstrap-filestyle.js
@@ -27,11 +27,18 @@
 
         $this.data('filestyle', true);
 
+        var parent = $this.parents(".control-group");
+
+        if (!parent.length) {
+          parent = $('<div></div>');
+          $this.before(parent);
+          parent.append($this);
+        }
+
+        parent.addClass("input-append");
+
         $this
           .css({'position':'fixed','top':'-100px','left':'-100px'})
-          .parents(".control-group")
-            .addClass("input-append")
-            .find("input[type=file]")
             .after(
               (options.textField ? '<input type="text" class="'+options.classText+'" disabled size="40" /> ' : '')+
                 '<button type="button" class="btn '+options.classButton+'" >'+


### PR DESCRIPTION
The current code assumes that the input (and its label) are wrapped in a div with class control-group. This is a pretty standard structure for forms in twitter bootstrap, but it's not mandatory. See the 'Default Styles' example at http://twitter.github.io/bootstrap/base-css.html#forms, or indeed the example HTML in https://github.com/markusslima/bootstrap-filestyle/blob/master/README.md

This patch uses the control-group div if it's present, and otherwise creates a new parent div in which to wrap the file upload input.
