### PR TITLE
Fix little CSS issue with required input attribute 

### DIFF
--- a/src/bootstrap-filestyle.js
+++ b/src/bootstrap-filestyle.js
@@ -174,7 +174,7 @@
 
             // hidding input file and add filestyle
             this.$element
-                .css({'position':'fixed','left':'-9999px'})
+                .css({'position':'absolute','clip':'rect(0,0,0,0)'})
                 .attr('tabindex', "-1")
                 .after(this.$elementFilestyle);
 


### PR DESCRIPTION
You use .css({'position':'absolute','left':'-9999px'}) to original button hiding. But, when the "required" attribute is set for this input, and user forgot to pick the file, browser show alarm on the leftmost window edge due to -9999.

Better way to avoid this - using .css({'position':'absolute','clip':'rect(0,0,0,0)'})
https://github.com/markusslima/bootstrap-filestyle/issues/45
