### PR TITLE
Placeholder functionality 

### DIFF
--- a/src/bootstrap-filestyle.js
+++ b/src/bootstrap-filestyle.js
@@ -150,6 +150,11 @@
 				return this.options.buttonName;
 			}
 		},
+		
+        	placeholder: function(value) {
+            		this.$elementFilestyle.find(':text').attr('placeholder', value);
+        	},
+
 
 		iconName : function(value) {
 			if (value !== undefined) {

--- a/src/bootstrap-filestyle.js
+++ b/src/bootstrap-filestyle.js
@@ -155,7 +155,6 @@
             		this.$elementFilestyle.find(':text').attr('placeholder', value);
         	},
 
-
 		iconName : function(value) {
 			if (value !== undefined) {
 				this.$elementFilestyle.find('.glyphicon').attr({


### PR DESCRIPTION
I have added three rows for adding placeholder functionality in the text input field.
Here is an example for using it:
```javascript
$(selector).filestyle('placeholder', 'My custom placeholder');
```