### PR TITLE
Travisdouce/redraw

### DIFF
--- a/src/bootstrap-filestyle.js
+++ b/src/bootstrap-filestyle.js
@@ -316,23 +316,32 @@
 		return this;
 	};
 
-	// Data attributes register
-	$(function() {
-		$('.filestyle').each(function() {
-			var $this = $(this), options = {
+        $.fn.filestyle.draw = function() {
+                $('.filestyle').each(function() {
+                        var $this = $(this), options = {
 
-				'input' : $this.attr('data-input') === 'false' ? false : true,
-				'icon' : $this.attr('data-icon') === 'false' ? false : true,
-				'buttonBefore' : $this.attr('data-buttonBefore') === 'true' ? true : false,
-				'disabled' : $this.attr('data-disabled') === 'true' ? true : false,
-				'size' : $this.attr('data-size'),
-				'buttonText' : $this.attr('data-buttonText'),
-				'buttonName' : $this.attr('data-buttonName'),
-				'iconName' : $this.attr('data-iconName'),
-				'badge' : $this.attr('data-badge') === 'false' ? false : true
-			};
+                                'input' : $this.attr('data-input') === 'false' ? false : true,
+                                'icon' : $this.attr('data-icon') === 'false' ? false : true,
+                                'buttonBefore' : $this.attr('data-buttonBefore') === 'true' ? true : false,
+                                'disabled' : $this.attr('data-disabled') === 'true' ? true : false,
+                                'size' : $this.attr('data-size'),
+                                'buttonText' : $this.attr('data-buttonText'),
+                                'buttonName' : $this.attr('data-buttonName'),
+                                'iconName' : $this.attr('data-iconName'),
+                                'badge' : $this.attr('data-badge') === 'false' ? false : true
+                  };
 
-			$this.filestyle(options);
-		});
-	});
+                  $this.filestyle(options);
+                });
+      };
+
+      $.fn.redraw = function() {
+                this.filestyle('destroy');
+                $.fn.filestyle.draw();
+      };
+
+      // Data attributes register
+      $(function() {
+                $.fn.filestyle.draw();
+      });
 })(window.jQuery);

--- a/src/bootstrap-filestyle.js
+++ b/src/bootstrap-filestyle.js
@@ -316,9 +316,10 @@
 		return this;
 	};
 
-        $.fn.filestyle.draw = function() {
-                $('.filestyle').each(function() {
-                        var $this = $(this), options = {
+        var draw = function(elements, customOptions) {
+                var customOptions = customOptions || {};
+                elements.each(function() {
+                        var $this = $(this), dataAttrOptions = {
 
                                 'input' : $this.attr('data-input') === 'false' ? false : true,
                                 'icon' : $this.attr('data-icon') === 'false' ? false : true,
@@ -330,18 +331,19 @@
                                 'iconName' : $this.attr('data-iconName'),
                                 'badge' : $this.attr('data-badge') === 'false' ? false : true
                   };
+                  var options = $.extend(dataAttrOptions, customOptions);
 
                   $this.filestyle(options);
                 });
       };
 
-      $.fn.redraw = function() {
+      $.fn.redraw = function(options) {
                 this.filestyle('destroy');
-                $.fn.filestyle.draw();
+                draw(this, options);
       };
 
       // Data attributes register
       $(function() {
-                $.fn.filestyle.draw();
+                draw($('.filestyle'));
       });
 })(window.jQuery);

--- a/test/index.html
+++ b/test/index.html
@@ -264,16 +264,25 @@
 					</div>
 					<div class="well">
 						<form role="form">
-							<h3>Styling newly added elements via data attributes</h3>
+							<h3>Styling newly added dom elements</h3>
 							<hr>
                                                                 <label>
                                                                         <button id="redraw" class="btn btn-default btn-xs" type="button">
-                                                                              Add New Element
+                                                                              Add New Elements
                                                                         </button>
                                                                 </label>
 							<div class="row">
 								<div class="col-xs-6">
-									<div id="new-element" class="form-group"></div>
+									<div id="new-element1" class="form-group">
+									      <label class="control-label">Style with data attributes</label>
+                                                                        </div>
+								</div>
+							</div>
+							<div class="row">
+								<div class="col-xs-6">
+									<div id="new-element2" class="form-group">
+									      <label class="control-label">Style with options</label>
+                                                                        </div>
 								</div>
 							</div>
 						</form>
@@ -378,10 +387,15 @@
 			});
 
 			$('#redraw').click(function() {
-                                var newDomElement = '<input type="file" id="input17"class="filestyle" data-iconName="glyphicon-camera" data-buttonText="Styled with data attributes">';
-                                $('#new-element').prepend(newDomElement);
-                                var input = $('#input17');
-                                input.redraw();
+                                var newDomElement1 = '<input type="file" id="input17"class="filestyle" data-iconName="glyphicon-camera" data-buttonText="Styled with data attributes">';
+                                $('#new-element1').append(newDomElement1);
+                                var newInput1 = $('#input17');
+                                newInput1.redraw();
+
+                                var newDomElement2 = '<input type="file" id="input18"class="filestyle" data-iconName="glyphicon-camera" data-buttonText="Should be overwritten">';
+                                $('#new-element2').append(newDomElement2);
+                                var newInput2 = $('#input18');
+                                newInput2.redraw({buttonText: 'Styled with options'});
 			});
 		</script>
 	</body>

--- a/test/index.html
+++ b/test/index.html
@@ -262,6 +262,22 @@
 							</div>
 						</form>
 					</div>
+					<div class="well">
+						<form role="form">
+							<h3>Styling newly added elements via data attributes</h3>
+							<hr>
+                                                                <label>
+                                                                        <button id="redraw" class="btn btn-default btn-xs" type="button">
+                                                                              Add New Element
+                                                                        </button>
+                                                                </label>
+							<div class="row">
+								<div class="col-xs-6">
+									<div id="new-element" class="form-group"></div>
+								</div>
+							</div>
+						</form>
+					</div>
 
 					<p>
 						View documentation: <a href="//markusslima.github.io/bootstrap-filestyle" target="_blank">Doc bootstrap filestyle</a>
@@ -359,6 +375,13 @@
 			// nultiple initialize
 			$('.test').filestyle({
 				buttonName : 'btn-primary'
+			});
+
+			$('#redraw').click(function() {
+                                var newDomElement = '<input type="file" id="input17"class="filestyle" data-iconName="glyphicon-camera" data-buttonText="Styled with data attributes">';
+                                $('#new-element').prepend(newDomElement);
+                                var input = $('#input17');
+                                input.redraw();
 			});
 		</script>
 	</body>


### PR DESCRIPTION
Adds method redraw

Existing problem:
Currently, it is not possible to style elements according to their filestyle
data attributes when added to the page via ajax (https://github.com/markusslima/bootstrap-filestyle/issues/15#issuecomment-18202798).

Solution:
Allow elements added to the page via ajax to be styled according to their
filestyle data attributes.