### PR TITLE
Input default text option & clear input button

### DIFF
--- a/src/bootstrap-filestyle.js
+++ b/src/bootstrap-filestyle.js
@@ -69,6 +69,30 @@
 			}
 		},
 
+		clearButton: function(value) {
+			if (value === true) {
+				if (!this.options.clearButton) {
+					this.options.clearButton = true;
+					if (this.options.input) {
+						this.$elementFilestyle.remove();
+						this.constructor();
+						this.pushNameFiles();
+					}
+				}
+			} else if (value === false) {
+				if (this.options.clearButton) {
+					this.options.clearButton = false;
+					if (this.options.input) {
+						this.$elementFilestyle.remove();
+						this.constructor();
+						this.pushNameFiles();
+					}
+				}
+			} else {
+				return this.options.clearButton;
+			}
+		},
+
 		icon : function(value) {
 			if (value === true) {
 				if (!this.options.icon) {
@@ -205,8 +229,10 @@
 
 			if (content !== '') {
 				this.$elementFilestyle.find(':text').val(content.replace(/\, $/g, ''));
+				this.$elementFilestyle.find('.clear-button').removeClass('hidden');
 			} else {
 				this.$elementFilestyle.find(':text').val('');
+				this.$elementFilestyle.find('.clear-button').addClass('hidden');
 			}
 			
 			return files;
@@ -218,6 +244,7 @@
 				id = _self.$element.attr('id'), 
 				files = [], 
 				btn = '', 
+				clearBtn = '',
 				$label;
 
 			if (id === '' || !id) {
@@ -235,7 +262,9 @@
 				  '</label>' + 
 				  '</span>';
 
-			html = _self.options.buttonBefore ? btn + _self.htmlInput() : _self.htmlInput() + btn;
+			clearBtn = _self.options.clearButton ? '<span class="input-group-btn"><button class="btn btn-default clear-button'+ (_self.options.inputText ? '' : ' hidden') +'" type="button">x</button></span>' : '';
+
+			html = _self.options.buttonBefore ? btn + _self.htmlInput() + clearBtn : clearBtn + _self.htmlInput() + btn;
 
 			_self.$elementFilestyle = $('<div class="bootstrap-filestyle input-group">' + html + '</div>');
 			_self.$elementFilestyle.find('.group-span-filestyle').attr('tabindex', "0").keypress(function(e) {
@@ -280,6 +309,24 @@
 					return false;
 				});
 			}
+
+			// Clear button click event handler
+			if (_self.options.clearButton){
+				var $clearButton = _self.$elementFilestyle.find('.clear-button');
+				$clearButton.on('click', function(e){
+					var $input = _self.$element,
+						input = $input[0];
+					try{
+						$input.val('');
+						if(input.value){
+							input.type = "text";
+							input.type = "file";
+						}
+						$clearButton.addClass('hidden');
+						$input.trigger('change');
+					} catch(e){}
+				});
+			}
 		}
 	};
 
@@ -318,6 +365,7 @@
 		'badge' : true,
 		'icon' : true,
 		'buttonBefore' : false,
+		'clearButton' : false,
 		'disabled' : false
 	};
 
@@ -331,16 +379,17 @@
 		$('.filestyle').each(function() {
 			var $this = $(this), options = {
 
-				'input' : $this.attr('data-input') === 'false' ? false : true,
+				'input' : $this.attr('data-input') !== 'false',
 				'inputText': $this.attr('data-inputText'),
-				'icon' : $this.attr('data-icon') === 'false' ? false : true,
-				'buttonBefore' : $this.attr('data-buttonBefore') === 'true' ? true : false,
-				'disabled' : $this.attr('data-disabled') === 'true' ? true : false,
+				'icon' : $this.attr('data-icon') !== 'false',
+				'buttonBefore' : $this.attr('data-buttonBefore') === 'true',
+				'clearButton' : $this.attr('data-clearButton') === 'true',
+				'disabled' : $this.attr('data-disabled') === 'true',
 				'size' : $this.attr('data-size'),
 				'buttonText' : $this.attr('data-buttonText'),
 				'buttonName' : $this.attr('data-buttonName'),
 				'iconName' : $this.attr('data-iconName'),
-				'badge' : $this.attr('data-badge') === 'false' ? false : true
+				'badge' : $this.attr('data-badge') !== 'false'
 			};
 
 			$this.filestyle(options);

--- a/src/bootstrap-filestyle.js
+++ b/src/bootstrap-filestyle.js
@@ -162,6 +162,15 @@
 			}
 		},
 
+		inputText : function(value) {
+			if (value !== undefined) {
+				this.options.inputText = value;
+				this.$elementFilestyle.find('input').text(this.options.inputText);
+			} else {
+				return this.options.inputText;
+			}
+		},
+
 		htmlIcon : function() {
 			if (this.options.icon) {
 				return '<span class="glyphicon ' + this.options.iconName + '"></span> ';
@@ -172,7 +181,7 @@
 
 		htmlInput : function() {
 			if (this.options.input) {
-				return '<input type="text" class="form-control ' + (this.options.size == 'nr' ? '' : 'input-' + this.options.size) + '" disabled> ';
+				return '<input type="text" class="form-control ' + (this.options.size == 'nr' ? '' : 'input-' + this.options.size) + ' "' + (this.options.inputText ? 'value="'+this.options.inputText+'" ': '') + 'disabled> ';
 			} else {
 				return '';
 			}
@@ -305,6 +314,7 @@
 		'buttonName' : 'btn-default',
 		'size' : 'nr',
 		'input' : true,
+		'inputText' : '',
 		'badge' : true,
 		'icon' : true,
 		'buttonBefore' : false,
@@ -322,6 +332,7 @@
 			var $this = $(this), options = {
 
 				'input' : $this.attr('data-input') === 'false' ? false : true,
+				'inputText': $this.attr('data-inputText'),
 				'icon' : $this.attr('data-icon') === 'false' ? false : true,
 				'buttonBefore' : $this.attr('data-buttonBefore') === 'true' ? true : false,
 				'disabled' : $this.attr('data-disabled') === 'true' ? true : false,

--- a/test/index.html
+++ b/test/index.html
@@ -263,6 +263,45 @@
 						</form>
 					</div>
 
+					<div class="well">
+						<form role="form">
+							<h3>Testing default input text & clear input button</h3>
+							<hr>
+							<div class="row">
+								<div class="col-xs-6">
+									<div class="form-group">
+										<label class="control-label">Input with default text initialized via data attribute</label>
+										<input type="file" class="filestyle" data-inputText="some_file.png">
+									</div>
+								</div>
+							</div>
+							<div class="row">
+								<div class="col-xs-6">
+									<div class="form-group">
+										<label class="control-label">Input with default text initialized via JS</label>
+										<input type="file" id="input17">
+									</div>
+								</div>
+							</div>
+							<div class="row">
+								<div class="col-xs-6">
+									<div class="form-group">
+										<label class="control-label">Clear input button initialized via data attribute (select file first)</label>
+										<input type="file" class="filestyle" data-clearButton="true">
+									</div>
+								</div>
+							</div>
+							<div class="row">
+								<div class="col-xs-6">
+									<div class="form-group">
+										<label class="control-label">Clear input button with default text initialized via JS</label>
+										<input type="file" id="input18">
+									</div>
+								</div>
+							</div>
+						</form>
+					</div>
+
 					<p>
 						View documentation: <a href="//markusslima.github.io/bootstrap-filestyle" target="_blank">Doc bootstrap filestyle</a>
 					</p>
@@ -273,7 +312,7 @@
 		<script type="text/javascript" src="js/bootstrap.min.js"></script>
 		<script type="text/javascript" src="../src/bootstrap-filestyle.js"></script>
 		<script type="text/javascript">
-			$('#input01').filestyle()
+			$('#input01').filestyle();
 
 			$('#input02').filestyle({
 				buttonText : 'My filestyle'
@@ -359,6 +398,14 @@
 			// nultiple initialize
 			$('.test').filestyle({
 				buttonName : 'btn-primary'
+			});
+
+			$('#input17').filestyle({
+				inputText: 'some_file.png'
+			});
+			$('#input18').filestyle({
+				inputText: 'some_file.png',
+				clearButton: true
 			});
 		</script>
 	</body>


### PR DESCRIPTION
1) Option for bootstrap-filestyle that allows to set input text on initialization - this is useful in forms that allow to "edit" given model. Having input initialized with text indicates that there is some image already uploaded.

2) Option for bootstrap-filestyle that allows to add "clear input" button - when initialized with flag set to 'true', clear button preprend / append is shown when input has a value. Clear button is hidden when there is no value set. Clear button position (prepend / append) is selected as opposite to "Select file" button position.
