### PR TITLE
Modifying the way ID are generated for input that does not have ID yet

### DIFF
--- a/src/bootstrap-filestyle.js
+++ b/src/bootstrap-filestyle.js
@@ -9,6 +9,8 @@
  */
 (function($) {"use strict";
 
+    var nextId = 0;
+
 	var Filestyle = function(element, options) {
 		this.options = options;
 		this.$elementFilestyle = [];
@@ -212,10 +214,11 @@
 				$label;
 
 			if (id === '' || !id) {
-				id = 'filestyle-' + $('.bootstrap-filestyle').length;
+				id = 'filestyle-' + nextId;
 				_self.$element.attr({
 					'id' : id
 				});
+                nextId++;
 			}
 
 			btn = '<span class="group-span-filestyle ' + (_self.options.input ? 'input-group-btn' : '') + '">' + 


### PR DESCRIPTION
I had a bug using your plugin inside a directive with Angular. Because sometime, the generated id value  for input where the same. This is due to the fact that you used to use the number of filestyle input to determine the id. But sometime, you are going to delete a file input and create a new one.