### PR TITLE
set placeholder when pushname called

### DIFF
--- a/src/bootstrap-filestyle.js
+++ b/src/bootstrap-filestyle.js
@@ -207,8 +207,10 @@
 
 			if (content !== '') {
 				this.$elementFilestyle.find(':text').val(content.replace(/\, $/g, ''));
+				this.placeholder(content.replace(/\, $/g, ''));
 			} else {
 				this.$elementFilestyle.find(':text').val('');
+				this.placeholder(''); 
 			}
 			
 			return files;


### PR DESCRIPTION
Does it's correct to set de placeholder with the pushname function. 

on the onchange event of the file type input the pushname function is called but the placeholder option is not set.
