### PR TITLE
Add a package.json so bootstrap-filestyle can be added to npm (#85).

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "bootstrap-filestyle",
+  "version": "1.2.1",
+  "description": "Bootstrap FileStyle is a quick and simple plugin to help style your form's file upload inputs.",
+  "main": "src/bootstrap-filestyle.js",
+  "directories": {
+    "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/markusslima/bootstrap-filestyle.git"
+  },
+  "keywords": [
+    "bootstrap",
+    "fileupload",
+    "filestyle"
+  ],
+  "author": "Markus Lima @markusslima",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/markusslima/bootstrap-filestyle/issues"
+  },
+  "homepage": "https://github.com/markusslima/bootstrap-filestyle#readme"
+}


### PR DESCRIPTION
Please merge this and use the `npm` tool to publish the package to npm.

People wanting to use bootstrap-filestyle with npm right now can install this fork currently by doing:

    npm install github:jaapz/bootstrap-filestyle