### PR TITLE
Added option to customise the badge text through the use of a callback function

### DIFF
--- a/src/bootstrap-filestyle.js
+++ b/src/bootstrap-filestyle.js
@@ -264,11 +264,13 @@
 
 				if (_self.options.input == false && _self.options.badge) {
 					if (_self.$elementFilestyle.find('.badge').length == 0) {
-						_self.$elementFilestyle.find('label').append(' <span class="badge">' + files.length + '</span>');
+                        var badgeVal = (_self.options.badgeCallback) ? _self.options.badgeCallback(files) : files.length;
+						_self.$elementFilestyle.find('label').append(' <span class="badge">' + badgeVal + '</span>');
 					} else if (files.length == 0) {
 						_self.$elementFilestyle.find('.badge').remove();
 					} else {
-						_self.$elementFilestyle.find('.badge').html(files.length);
+                        var badgeVal = (_self.options.badgeCallback) ? _self.options.badgeCallback(files) : files.length;
+						_self.$elementFilestyle.find('.badge').html(badgeVal);
 					}
 				} else {
 					_self.$elementFilestyle.find('.badge').remove();
@@ -321,7 +323,8 @@
 		'icon' : true,
 		'buttonBefore' : false,
 		'disabled' : false,
-		'placeholder': ''
+		'placeholder': '',
+        'badgeCallback' : null
 	};
 
 	$.fn.filestyle.noConflict = function() {


### PR DESCRIPTION
Allows badge text to be customised, for example to show the file name when only one file is chosen

$(":file").filestyle({
badgeCallback: function (files) {
return files.length == 1 ? files[0].name : files.length;
}
});
