### PR TITLE
Create composer.json for instalation with composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+  "name": "markusslima/bootstrap-filestyle",
+  "description": "jQuery customization of input html file for Bootstrap Twitter http://markusslima.github.io/bootstrap-filestyle/",
+  "type": "component",
+  "homepage": "http://markusslima.github.io/bootstrap-filestyle/",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Markus Lima Luthier",
+      "email": "markusslima@gmail.com"
+    }
+  ],
+  "require": {
+    "robloach/component-installer": "*",
+    "components/bootstrap": "*"
+  },
+  "extra": {
+    "component": {
+      "scripts": [
+        "src/bootstrap-filestyle.js"
+      ],
+      "files": [
+        "src/bootstrap-filestyle.min.js"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The installation is much simpler with Composer and https://github.com/RobLoach/component-installer

After merged you can test it:
```
composer config repositories.markusslima-bootstrap-filestyle vcs "https://github.com/markusslima/bootstrap-filestyle"
composer require markusslima/bootstrap-filestyle:dev-master
```
Before merged you can test using my git fork.

Composer creates a "components" folder that contains the "bootstrap-filestyle" whith all files spec in "files" of composer.json.
You can then register the "package" at https://packagist.org In this way the installation would be simpler:
`composer require markusslima/bootstrap-filestyle:dev-master`